### PR TITLE
feat: 更新Nuxt配置，启用i18n支持

### DIFF
--- a/www/nuxt.config.ts
+++ b/www/nuxt.config.ts
@@ -2,25 +2,15 @@
 export default defineNuxtConfig({
   devtools: { enabled: true },
   extends: ['..'],
-  // i18n: {
-  //   defaultLocale: 'en',
-  //   locales: [
-  //     {
-  //       code: 'en',
-  //       name: 'English',
-  //       language: 'en-US',
-  //     },
-  //     {
-  //       code: 'fr',
-  //       name: 'Français',
-  //       language: 'fr-FR',
-  //     },
-  //     {
-  //       code: 'km',
-  //       name: 'ភាសាខ្មែរ',
-  //       language: 'km-KH',
-  //     },
-  //   ],
-  // },
+  i18n: {
+    defaultLocale: 'en',
+    locales: [
+      {
+        code: 'en',
+        name: 'English',
+        language: 'en-US',
+      },
+    ],
+  },
   compatibilityDate: '2025-05-13',
 });


### PR DESCRIPTION
- 在nuxt.config.ts中启用i18n配置，设置默认语言为英语，并添加语言选项，提升多语言支持能力。
- 移除冗余的注释，简化配置文件，提高可读性和维护性。